### PR TITLE
Fixing path in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module scum
+module github.com/hansmannj/scum
 
 go 1.13
 


### PR DESCRIPTION
As go get is deprecated, installing via go install throws module declares itself as scum but was required as github.com/unprofession-al/scum. Adapting the path in go.mod might fix this. This commit ist to test that.